### PR TITLE
innodb の buffer pool size が小さすぎるので修正

### DIFF
--- a/webapp/etc/my.cnf
+++ b/webapp/etc/my.cnf
@@ -4,3 +4,4 @@ slow_query_log=1
 long_query_time=1
 log_queries_not_using_indexes=1
 slow_query_log_file=/usr/local/var/mysql/slow_query.log
+innodb_buffer_pool_size=1.2G


### PR DESCRIPTION
マシンメモリの 75% というのがありましたが、他の使用状況もあるので、安定で 1.2 G にしています。
参考: https://qiita.com/stomk/items/6265e9fdfdfb4f104a7e#innodb_buffer_pool_size