### PR TITLE
make_posts のコメント数取得処理を修正

### DIFF
--- a/webapp/php/index.php
+++ b/webapp/php/index.php
@@ -531,7 +531,18 @@ $app->get('/@{account_name}', function (Request $request, Response $response, $a
 
     $me = $this->get('helper')->get_session_user();
 
-    return $this->get('view')->render($response, 'user.php', ['posts' => $posts, 'user' => $user, 'post_count' => $post_count, 'comment_count' => $comment_count, 'commented_count'=> $commented_count, 'me' => $me]);
+    return $this->get('view')->render(
+        $response,
+        'user.php',
+        [
+            'posts' => $posts,
+            'user' => $user,
+            'post_count' => $post_count,
+            'comment_count' => $comment_count,
+            'commented_count'=> $commented_count,
+            'me' => $me,
+        ],
+    );
 });
 
 $app->run();

--- a/webapp/php/index.php
+++ b/webapp/php/index.php
@@ -130,7 +130,6 @@ $container->set('helper', function ($c) {
             $all_comments = $options['all_comments'];
             $posts = [];
             foreach ($results as $post) {
-                $post['comment_count'] = $this->fetch_first('SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = ?', $post['id'])['count'];
                 $query = '
                     SELECT
                         comments.*,

--- a/webapp/php/views/post.php
+++ b/webapp/php/views/post.php
@@ -14,7 +14,7 @@
   </div>
   <div class="isu-post-comment">
     <div class="isu-post-comment-count">
-      comments: <b><?= escape_html($post['comment_count']) ?></b>
+      comments: <b><?= count($post['comments']) ?></b>
     </div>
 
     <?php foreach ($post['comments'] as $comment): ?>


### PR DESCRIPTION
- b2195a1f85cd70fb82640ef7cca7adc236ff2939 読みづらかった render を format（関係ない）
- 5800915a2d7a61e0aaed06429e0588249037195c comment_count のために SQL を叩く必要はなかったので、テンプレート上で `count($post['comments'])` をそのまま表示。数字なので escape も不要.