### PR TITLE
投稿数の制限を SQL 時点で行う

### DIFF
--- a/webapp/php/index.php
+++ b/webapp/php/index.php
@@ -313,8 +313,13 @@ $app->get('/', function (Request $request, Response $response) {
     $me = $this->get('helper')->get_session_user();
 
     $db = $this->get('db');
-    $ps = $db->prepare('SELECT `id`, `user_id`, `body`, `mime`, `created_at` FROM `posts` ORDER BY `created_at` DESC');
-    $ps->execute();
+    $ps = $db->prepare("
+        SELECT `id`, `user_id`, `body`, `mime`, `created_at`
+        FROM `posts`
+        ORDER BY `created_at` DESC
+        LIMIT ?
+    ");
+    $ps->execute([POSTS_PER_PAGE]);
     $results = $ps->fetchAll(PDO::FETCH_ASSOC);
     $posts = $this->get('helper')->make_posts($results);
 
@@ -510,8 +515,14 @@ $app->get('/@{account_name}', function (Request $request, Response $response, $a
         return $response->withStatus(404);
     }
 
-    $ps = $db->prepare('SELECT `id`, `user_id`, `body`, `created_at`, `mime` FROM `posts` WHERE `user_id` = ? ORDER BY `created_at` DESC');
-    $ps->execute([$user['id']]);
+    $ps = $db->prepare("
+        SELECT `id`, `user_id`, `body`, `created_at`, `mime`
+        FROM `posts`
+        WHERE `user_id` = ?
+        ORDER BY `created_at` DESC
+        LIMIT ?
+    ");
+    $ps->execute([$user['id'], POSTS_PER_PAGE]);
     $results = $ps->fetchAll(PDO::FETCH_ASSOC);
     $posts = $this->get('helper')->make_posts($results);
 


### PR DESCRIPTION
投稿数の制限が、make_posts のループ内で制限されているため、そもそも LIMIT で 20 件以上取得されないようにする。